### PR TITLE
fix: install missing workflow states

### DIFF
--- a/freight_management/hooks.py
+++ b/freight_management/hooks.py
@@ -64,6 +64,7 @@ fixtures = [{
 
 # before_install = "freight_management.install.before_install"
 # after_install = "freight_management.install.after_install"
+after_sync = "freight_management.sync.after_sync"
 
 # Uninstallation
 # ------------

--- a/freight_management/patches.txt
+++ b/freight_management/patches.txt
@@ -1,4 +1,1 @@
-[pre_model_sync]
-
-[post_model_sync]
 freight_management.patches.install_missing_workflow_states

--- a/freight_management/patches.txt
+++ b/freight_management/patches.txt
@@ -1,0 +1,4 @@
+[pre_model_sync]
+
+[post_model_sync]
+freight_management.patches.install_missing_workflow_states

--- a/freight_management/patches/install_missing_workflow_states.py
+++ b/freight_management/patches/install_missing_workflow_states.py
@@ -1,0 +1,5 @@
+from freight_management.sync import install_missing_workflow_states
+
+
+def execute():
+	install_missing_workflow_states()

--- a/freight_management/sync.py
+++ b/freight_management/sync.py
@@ -1,0 +1,24 @@
+import frappe
+
+
+def install_missing_workflow_states():
+	existing_states = frappe.db.get_all("Workflow State", pluck="name")
+	required_states = set()
+
+	for workflow_name in ["Revision", "Direct Shipping Workflow"]:
+		workflow = frappe.get_doc("Workflow", workflow_name)
+		for state in workflow.states:
+			required_states.add(state.state)
+
+	for state in required_states:
+		if state not in existing_states:
+			frappe.get_doc({
+				"doctype": "Workflow State",
+				"workflow_state_name": state
+			}).insert(ignore_permissions=True)
+
+	frappe.db.commit()
+
+
+def after_sync():
+	install_missing_workflow_states()


### PR DESCRIPTION
This app uses references workflow states not installed by default with ERPNext.

This PR will install missing workflow states from `Revision`, `Direct Shipping Workflow` workflows when the app is installed.

For anyone who installed the app already, I've added a patch that will install the missing workflow states.